### PR TITLE
Add a "recently closed" section to the main page.

### DIFF
--- a/bugz.js
+++ b/bugz.js
@@ -56,6 +56,10 @@ class Bug {
   get mentors() {
     return [];
   }
+
+  get resolution() {
+    return "";
+  }
 }
 
 class GithubIssue extends Bug {
@@ -90,6 +94,10 @@ class BugzillaBug extends Bug {
 
   get mentors() {
     return this._data.mentors;
+  }
+
+  get resolution() {
+    return this._data.resolution;
   }
 }
 
@@ -175,6 +183,13 @@ async function loadBugsFromBugzilla(searchParams) {
     if ("open" in filters) {
       if (filters.open) {
         queryParams.resolution = "---";
+      } else {
+        queryParams.resolution = ["FIXED",
+                                  "INVALID",
+                                  "WONTFIX",
+                                  "DUPLICATE",
+                                  "WORKSFORME",
+                                  "INCOMPLETE"];
       }
     }
     if ("isAssigned" in filters) {
@@ -184,6 +199,9 @@ async function loadBugsFromBugzilla(searchParams) {
     }
     if ("whiteboard" in filters) {
       queryParams.whiteboard = filters.whiteboard;
+    }
+    if ("lastChangeTime" in filters) {
+      queryParams.last_change_time = filters.lastChangeTime.toISOString();
     }
   }
 
@@ -198,6 +216,7 @@ async function loadBugsFromBugzilla(searchParams) {
     "cf_fx_points",
     "priority",
     "mentors",
+    "resolution",
   ].join(",");
   queryParams.include_fields = include_fields;
 
@@ -226,6 +245,7 @@ async function loadBugsFromBugzilla(searchParams) {
       product: b.product,
       component: b.component,
       mentors: b.mentors,
+      resolution: b.resolution,
     };
 
     if (b.assigned_to !== "nobody@mozilla.org") {

--- a/dash.js
+++ b/dash.js
@@ -246,6 +246,32 @@ let bugLists = new Map([
         })),
       ],
     }],
+    ["recently closed", {
+      columns: ["assignee", "title", "project", "resolution"],
+      searches: [
+        {
+          search: {
+            type: "bugzillaWhiteboard",
+            whiteboardContent: "[measurement:client:tracking]",
+          },
+          filters: {
+            open: false,
+            lastChangeTime: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000),
+          },
+        },
+        ... telemetryBugzillaProjects.map(p => ({
+          search: {
+            type: "bugzillaComponent",
+            product: p.product,
+            component: p.component,
+          },
+          filters: {
+            open: false,
+            lastChangeTime: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000),
+          },
+        })),
+      ],
+    }],
   ])],
 
   /**************************************************************************


### PR DESCRIPTION
Fixes #15

This isn't actually a list of recently-closed bugs due to the complexity of
searching bug histories for exactly when a bug was closed.

Instead it is a list of closed bugs that were modified recently. Which seems to
be close enough in practice.